### PR TITLE
Security Fix

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -4,6 +4,7 @@ const database = require('./database.js')
 const express = require('express')
 const pino = require('pino');
 const expressPino = require('express-pino-logger');
+const crypto = require('crypto');
 
 const logger = pino({level: process.env.LOG_LEVEL || 'info'});
 const expressLogger = expressPino({logger});
@@ -20,7 +21,15 @@ const io = Server(http, {pingTimeout: 10000});
 import {Game} from "../briscola/js/Game.js"
 
 var session = require("express-session")({
-    secret: "my-secret",
+    // Signing secret for the connect.sid cookie. Never hard-code it: a known
+    // or guessable secret lets an attacker forge validly-signed session
+    // cookies. Load it from the environment; fall back to a random per-boot
+    // secret when unset (that invalidates existing sessions on restart, which
+    // is safe here as clients rebind on reconnect).
+    // NOTE: also set `cookie: { secure: true }` once the site is served over
+    // TLS. resave/saveUninitialized are intentionally left as-is because the
+    // socket turn-authorization currently relies on the per-connection session.
+    secret: process.env.SESSION_SECRET || crypto.randomBytes(32).toString("hex"),
     resave: true,
     saveUninitialized: true
 });
@@ -98,29 +107,32 @@ function BackendServer() {
         let session = socket.handshake.session;
         socket.on(Constants.events.REQUEST_GAME_START, async function (playerName) {
             if (socket.handshake.query.gameId) {
-                let game = await database.getGame(socket.handshake.query.gameId);
-                if (game.started) {
-                    //this game already started. The user refreshed the page on an existing game. Redirecting to new game
-                    socket.emit(Constants.events.REDIRECT, `/new?name=${playerName}&gameType=${game.gameType}`)
+                let existing = await database.getGame(socket.handshake.query.gameId);
+                if (!existing) {
                     return;
                 }
-                let playerIndex = 0;
-                if (game.players[0].socketId == undefined) {
-                    playerIndex = 0;
-                    game.player1.socketId = socket.id
-                } else if (game.players[1].socketId == undefined) {
-                    //len 1
-                    playerIndex = 1;
-                    game.player2.socketId = socket.id
+                if (existing.started) {
+                    //this game already started. The user refreshed the page on an existing game. Redirecting to new game
+                    socket.emit(Constants.events.REDIRECT, `/new?name=${playerName}&gameType=${existing.gameType}`)
+                    return;
                 }
+
+                // Atomically claim a free seat (fixes the seat-hijack race and
+                // removes the "default to seat 0" clobber on a full game).
+                const claim = await database.claimSeat(socket.handshake.query.gameId, socket.id, playerName)
+                if (!claim) {
+                    //no free seat (game full or already started) — send elsewhere
+                    //instead of overwriting player 1's seat.
+                    socket.emit(Constants.events.REDIRECT, `/new?name=${playerName}&gameType=${existing.gameType}`)
+                    return;
+                }
+
+                let game = claim.game;
+                let playerIndex = claim.playerIndex;
                 session.playerIndex = playerIndex
                 session.gameId = game._id
-
-                game.players[playerIndex].socketId = socket.id;
-                game.players[playerIndex].name = playerName;
                 game.playerForClientSide = game.players[playerIndex]
 
-                await database.saveGame(game)
                 lobbies.addLobby(game);
                 if (game.players[0].socketId && game.players[1].socketId) {
                     const isPlayer1Connected = isSocketConnected(game.players[0].socketId)
@@ -135,12 +147,16 @@ function BackendServer() {
                             //player 1 left
                             logger.info("Player 1 left before game could be started.. Resetting player 1", game._id)
                             game.players[0].socketId = undefined//waits for another player
+                            if (game.player1) game.player1.socketId = undefined
                         }
                         if (!isPlayer2Connected) {
                             //player 2 left
                             logger.info("Player 2 left before game could be started.. Resetting player 2", game._id)
                             game.players[1].socketId = undefined//waits for another player
+                            if (game.player2) game.player2.socketId = undefined
                         }
+                        //persist the freed seat so the claim is actually released
+                        await database.saveGame(game)
                     }
 
                 }

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -39,6 +39,33 @@ io.use(sharedsession(session, {
 }));
 
 
+// --- Security: per-recipient game redaction -------------------------------
+// The raw game object holds BOTH players' hands and the entire undrawn deck
+// in draw order. Emitting it to every client leaks the opponent's hand and
+// lets any player predict every future draw (see the game-state-disclosure
+// finding). Build a view that keeps only what the recipient is entitled to
+// (their own hand, the public trump, piles, scores) and replaces the
+// opponent's hand and the undrawn deck with same-length placeholders, so the
+// client still renders the right number of card backs / remaining-deck size
+// without any hidden values ever reaching the wire.
+function redactCards(cards) {
+    return Array.isArray(cards) ? cards.map(function () { return {rank: null, suit: null}; }) : cards;
+}
+
+function redactGameForPlayer(game, index) {
+    const view = cloneDeep(game);
+    view.playerForClientSide = view.players[index];
+
+    const opponent = view.players[1 - index];
+    if (opponent && opponent.hand) {
+        opponent.hand.cards = redactCards(opponent.hand.cards);
+    }
+    if (view.deck) {
+        view.deck.cards = redactCards(view.deck.cards);
+    }
+    return view;
+}
+
 function BackendServer() {
     expressApp.use(express.static(__dirname))
 
@@ -122,14 +149,13 @@ function BackendServer() {
 
             function emitGetGame(game) {
                 game.players.forEach(function (player, index) {
-                    const deepCopyGame = cloneDeep(game)
-                    deepCopyGame.playerForClientSide = deepCopyGame.players[index];
+                    const view = redactGameForPlayer(game, index)
                     if (socket.id === player.socketId) {
                         //the current player made this request so we have to send it normally with socket.emit()
-                        socket.emit(Constants.events.GET_GAME, deepCopyGame)
+                        socket.emit(Constants.events.GET_GAME, view)
                     } else {
                         //this player is not the current socket, so we can send a message to the default room of this player with .emit()
-                        io.to(player.socketId).emit(Constants.events.GET_GAME, deepCopyGame)
+                        io.to(player.socketId).emit(Constants.events.GET_GAME, view)
                     }
 
                 })
@@ -160,14 +186,13 @@ function BackendServer() {
 
             function emitGetGame(game) {
                 game.players.forEach(function (player, index) {
-                    const deepCopyGame = cloneDeep(game)
-                    deepCopyGame.playerForClientSide = deepCopyGame.players[index];
+                    const view = redactGameForPlayer(game, index)
                     if (socket.id === player.socketId) {
                         //the current player made this request so we have to send it normally with socket.emit()
-                        socket.emit(Constants.events.GET_GAME, deepCopyGame)
+                        socket.emit(Constants.events.GET_GAME, view)
                     } else {
                         //this player is not the current socket, so we can send a message to the default room of this player with .emit()
-                        io.to(player.socketId).emit(Constants.events.GET_GAME, deepCopyGame)
+                        io.to(player.socketId).emit(Constants.events.GET_GAME, view)
                     }
 
                 })
@@ -218,7 +243,14 @@ function BackendServer() {
                         emitGameOver(game)
                     }
 
-                    emitEvent(game, Constants.events.ROUND_OVER, winningPlayer)
+                    // Don't ship the winner's hand to the loser. The client
+                    // ignores this payload's contents, but it must not leak on
+                    // the wire; send a copy with the hand redacted.
+                    const roundWinnerView = cloneDeep(winningPlayer)
+                    if (roundWinnerView.hand) {
+                        roundWinnerView.hand.cards = redactCards(roundWinnerView.hand.cards)
+                    }
+                    emitEvent(game, Constants.events.ROUND_OVER, roundWinnerView)
                 }
 
                 emitEvent(game, Constants.events.CARD_PLAYED, cardPlayed)//tell clients that a card was played so that it will get displayed
@@ -246,26 +278,24 @@ function BackendServer() {
 
         function emitUpdateGame(game) {
             game.players.forEach(function (player, index) {
-                const deepCopyGame = cloneDeep(game)
-                deepCopyGame.playerForClientSide = deepCopyGame.players[index];
+                const view = redactGameForPlayer(game, index)
                 if (socket.id === player.socketId) {
                     //the current player made this request so we have to send it normally with socket.emit()
-                    socket.emit(Constants.events.UPDATE_GAME, deepCopyGame)
+                    socket.emit(Constants.events.UPDATE_GAME, view)
                 } else {
                     //this player is not the current socket, so we can send a message to the default room of this player with .emit()
-                    io.to(player.socketId).emit(Constants.events.UPDATE_GAME, deepCopyGame)
+                    io.to(player.socketId).emit(Constants.events.UPDATE_GAME, view)
                 }
             })
         }
 
         function emitGameOver(game) {
             game.players.forEach(function (player, index) {
-                const deepCopyGame = cloneDeep(game)
-                deepCopyGame.playerForClientSide = deepCopyGame.players[index];
+                const view = redactGameForPlayer(game, index)
                 if (socket.id === player.socketId) {
-                    socket.emit(Constants.events.GAME_OVER, deepCopyGame)
+                    socket.emit(Constants.events.GAME_OVER, view)
                 } else {
-                    io.to(player.socketId).emit(Constants.events.GAME_OVER, deepCopyGame)
+                    io.to(player.socketId).emit(Constants.events.GAME_OVER, view)
                 }
             })
         }

--- a/backend/database.js
+++ b/backend/database.js
@@ -113,7 +113,63 @@ async function saveGame(game)
 }
 
 
+/**
+ * Atomically claim a free seat in a not-yet-started game.
+ *
+ * Fixes the seat-hijack race: previously REQUEST_GAME_START read the game,
+ * picked an empty seat in memory, then saved — so two concurrent joiners could
+ * both read the same seat as empty and overwrite each other (and a joiner to a
+ * full game defaulted to seat 0, clobbering player 1). Here the emptiness check
+ * and the write happen in a single findOneAndUpdate, so only one caller can win
+ * a given seat.
+ *
+ * Seats are tried in order (player1 then player2). The filter `<seat>: null`
+ * matches both null and a missing field, so a freshly-inserted game qualifies.
+ *
+ * @param {String} id game ObjectId (string or ObjectID)
+ * @param {String} socketId claiming socket's id
+ * @param {String} playerName
+ * @returns {Promise<{playerIndex:number, game:Object}|null>} claimed seat + the
+ *          updated game document, or null if no seat is free / the game started.
+ */
+async function claimSeat(id, socketId, playerName)
+{
+    if (typeof id === "string") {
+        id = ObjectID(id)
+    }
+    const seats = [
+        {index: 0, seat: "player1", arr: "players.0"},
+        {index: 1, seat: "player2", arr: "players.1"}
+    ]
+    const connectedClient = await client
+    const collection = connectedClient
+        .db(process.env.DB_GAMES_DATABASE_NAME)
+        .collection(process.env.DB_GAMES_COLLECTION_NAME)
+
+    for (const s of seats) {
+        const set = {}
+        set[s.seat + ".socketId"] = socketId
+        set[s.seat + ".name"] = playerName
+        set[s.arr + ".socketId"] = socketId
+        set[s.arr + ".name"] = playerName
+
+        const filter = {_id: id, started: {$ne: true}}
+        filter[s.seat + ".socketId"] = null // matches null OR missing
+
+        const result = await collection.findOneAndUpdate(
+            filter,
+            {$set: set},
+            {returnOriginal: false} // mongodb v3 driver: return the updated doc
+        )
+        if (result && result.value) {
+            return {playerIndex: s.index, game: result.value}
+        }
+    }
+    return null // no free seat (game full or already started)
+}
+
 module.exports.getGame = getGame;
+module.exports.claimSeat = claimSeat;
 module.exports.insertNewGame = insertNewGame;
 module.exports.insertNewGameString = insertNewGameString;
 module.exports.saveGame = saveGame;

--- a/briscola/js/eventHandlers.js
+++ b/briscola/js/eventHandlers.js
@@ -3,7 +3,8 @@ import { Constants } from './Constants.js'
 
 const urlParams = new URLSearchParams(window.location.search);
 const gameId = urlParams.get('gameId');
-const socket = io(`http://${window.location.hostname}:3000?gameId=`+gameId )
+// Same-origin: proxied through nginx (:80) instead of the exposed :3000.
+const socket = io(`${window.location.origin}?gameId=`+gameId )
 function _onCardPress(arg, game)
 {
     const cardPressed = arg.currentTarget.card

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,11 @@ services:
     build:
       context: .
       dockerfile: BackendDockerfile
-    ports:
-      - "3000:3000"
+    # Not published to the host: nginx reaches it in-network as backend:3000
+    # (socket.io is proxied via the /socket.io/ location). Publishing :3000
+    # directly bypassed nginx and exposed the game server (and its CORS *).
+    expose:
+      - "3000"
   react:
     restart: always
     build:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -56,6 +56,18 @@ http {
         location /newAgainstComputer {
           proxy_pass http://backend:3000/newAgainstComputer;
         }
+
+        # Proxy the socket.io game server (WebSocket) so clients reach it
+        # same-origin via :80 instead of the directly-published :3000.
+        location /socket.io/ {
+          proxy_pass http://backend:3000;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
         #error_page  404              /404.html;
 
         # redirect server error pages to the static page /50x.html

--- a/react/infra/nginx/nginx.conf
+++ b/react/infra/nginx/nginx.conf
@@ -49,6 +49,18 @@ http {
             proxy_pass http://backend:3000/join;
         }
 
+        # Proxy the socket.io game server (WebSocket) so clients reach it
+        # same-origin instead of the directly-published :3000.
+        location /socket.io/ {
+            proxy_pass http://backend:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         #error_page  404              /404.html;
 
         # redirect server error pages to the static page /50x.html

--- a/react/src/game/Game.tsx
+++ b/react/src/game/Game.tsx
@@ -201,7 +201,9 @@ const Game: React.FC = () => {
 
     // ── Socket ──
     const gameId = getGameId();
-    const socket: SocketIOInstance = io(`http://${window.location.hostname}:3000?gameId=${gameId}`);
+    // Connect same-origin so traffic is proxied through nginx (:80) rather
+    // than the directly-exposed :3000. socket.io uses the default /socket.io path.
+    const socket: SocketIOInstance = io(`${window.location.origin}?gameId=${gameId}`);
     socketRef.current = socket;
 
     // Request game start


### PR DESCRIPTION
## Summary

Fixes a set of server-side security issues in the socket.io game backend,
found during an authorized review. The headline bug let any player see their
opponent's hand and the full deck order; the rest harden the join path and the
deployment surface. Core game-move validation (card ownership, turn order,
pile scoring) was already sound and is unchanged.

No gameplay behavior changes for legitimate clients — payloads keep the same
shape and the same counts; only hidden values are removed.

## Findings addressed

| Sev | Issue | Fix |
|-----|-------|-----|
| **High** | Omniscient game-state disclosure — every client received the full game object (opponent's hand + entire undrawn deck in draw order) | Per-recipient redaction before emit |
| **Medium** | Seat-hijack race in `REQUEST_GAME_START` — concurrent joiners could both claim a seat / overwrite player 1 | Atomic seat claim via `findOneAndUpdate` |
| **Low** | Hardcoded `express-session` secret (`"my-secret"`) — forgeable `connect.sid` | Load secret from environment |
| **Info** | `socket.io` published directly on `:3000`, bypassing nginx (with `Access-Control-Allow-Origin: *`) | Proxy socket.io through nginx; stop publishing `:3000` |

## Changes by commit

**`fix(security): redact per-recipient game state` (High)**
- The emit helpers cloned the game and only reassigned the `playerForClientSide`
  pointer, so `GET_GAME` / `UPDATE_GAME` / `GAME_OVER` / `ROUND_OVER` shipped
  both players' hands and the undrawn deck to everyone. Clients render card
  backs, but the values were on the wire — any joiner with the shareable
  `gameId` could read the opponent's hand and predict every future draw.
- Adds `redactGameForPlayer(game, index)`: deep-clones, sets
  `playerForClientSide`, and replaces the **opponent's `hand.cards`** and the
  **undrawn `deck.cards`** with same-length `{rank:null, suit:null}`
  placeholders. Clients still get the correct card-back / deck-size counts.
- Routes all four emit helpers through it and redacts the winner's hand in the
  `ROUND_OVER` payload (which fires per trick, when hands are refilled).

**`harden(net): proxy socket.io through nginx; stop publishing backend :3000` (Info)**
- nginx (both configs): add a `location /socket.io/` WebSocket proxy to
  `backend:3000`.
- Clients (`react/src/game/Game.tsx`, `briscola/js/eventHandlers.js`): connect
  same-origin via `window.location.origin` instead of hard-coded `:3000`.
- `docker-compose.yml`: backend `ports: 3000:3000` → `expose`, so the game
  server (and its `CORS *`) is reachable only in-network via nginx.

**`fix(security): atomic seat claim (MED-02) + env-based session secret (MED-01)`**
- MED-02: `REQUEST_GAME_START` read the game, chose a seat in memory, then
  saved — so two concurrent joiners could both read a seat as empty and
  overwrite each other, and a joiner to a full game defaulted to seat 0
  (clobbering player 1). Adds `database.claimSeat()`, which claims a free seat
  with a single `findOneAndUpdate` whose filter asserts the seat is still empty
  and the game hasn't started, so only one caller wins a seat. When no seat is
  free the joiner is redirected to a new game instead of overwriting seat 0.
  The disconnect-mid-join path now persists the freed seat.
- MED-01: `secret: "my-secret"` → `process.env.SESSION_SECRET` with a random
  per-boot fallback. `resave`/`saveUninitialized` are intentionally unchanged
  (the socket turn-authorization relies on the per-connection session).

## Deploy notes

- Set **`SESSION_SECRET`** (a long random value) in the backend environment so
  sessions survive restarts. Without it, a random secret is generated each boot
  (safe, but existing sessions are invalidated on restart).
- The socket.io + compose change requires rebuilding the **nginx/react** and
  **backend** images. After the change, clients reach socket.io same-origin
  through nginx on `:80`; the backend no longer needs a published host port.
